### PR TITLE
change all instances of 'dock.findChild' to 'mw.findChild'

### DIFF
--- a/RuneScape-Gamification/__init__.py
+++ b/RuneScape-Gamification/__init__.py
@@ -50,11 +50,9 @@ def skill_label_color_change(skill_label, duration):
     #skill_label.setStyleSheet("color: white;")
     skill_label.setStyleSheet("")
 
-def level_up(skill_label, skill):
-    # get the dock widget
-    dock = mw.findChild(QtWidgets.QDockWidget)    
+def level_up(skill_label, skill):   
     # get the label that displays the skill
-    skill_label = dock.findChild(QtWidgets.QLabel, f"{skill}_label")
+    skill_label = mw.findChild(QtWidgets.QLabel, f"{skill}_label")
     # change the text color of the label to orange
     skill_label.setStyleSheet("color: green;")
     skill_label.setText("{} {}".format(skill_symbols[skill], skills[skill]["level"]))
@@ -63,10 +61,8 @@ def level_up(skill_label, skill):
     thread.start()  # start the thread
     
 def animate_xp_gain(skill):
-    # get the dock widget
-    dock = mw.findChild(QtWidgets.QDockWidget)
     # get the label that displays the skill
-    skill_label = dock.findChild(QtWidgets.QLabel, f"{skill}_label")
+    skill_label = mw.findChild(QtWidgets.QLabel, f"{skill}_label")
     # change the text color of the label to orange
     skill_label.setStyleSheet("color: orange;")
     # create a thread to update the position of the skill label
@@ -81,10 +77,8 @@ def increase_skill_progress(skill, amount):
     if skills[skill]["xp"] >= level_xp[skills[skill]["level"]]:
        skills[skill]["level"] += 1
        skills[skill]["xp"] -= level_xp[skills[skill]["level"] - 1]
-       # get the dock widget
-       dock = mw.findChild(QtWidgets.QDockWidget)
        # get the label that displays the skill
-       skill_label = dock.findChild(QtWidgets.QLabel, f"{skill}_label")
+       skill_label = mw.findChild(QtWidgets.QLabel, f"{skill}_label")
        # update the text of the label to display the updated level
        # show the level up animation for the skill label
        level_up(skill_label, skill)
@@ -93,10 +87,8 @@ def increase_skill_progress(skill, amount):
        animate_xp_gain(skill)
        
 def update_skill_tool_tip(skill):
-    # get the dock widget
-    dock = mw.findChild(QtWidgets.QDockWidget)
     # get the label that displays the skill
-    skill_label = dock.findChild(QtWidgets.QLabel, f"{skill}_label")
+    skill_label = mw.findChild(QtWidgets.QLabel, f"{skill}_label")
     # update the tool tip for the label to display the updated skill level and XP of the tool tip
     skill_label.setToolTip("{} Level {} ({}/{} XP)".format(skill, skills[skill]["level"], skills[skill]["xp"], level_xp[skills[skill]["level"]]))
        


### PR DESCRIPTION
**Tested on Linux Popos 20.04 and Windows 10**
- haven't tested it on Mac.

In the function
```python
def animate_xp_gain(skill):
    # get the dock widget
    dock = mw.findChild(QtWidgets.QDockWidget)
    # get the label that displays the skill
    skill_label = dock.findChild(QtWidgets.QLabel, f"{skill}_label")
    # change the text color of the label to orange
    skill_label.setStyleSheet("color: orange;")
    # create a thread to update the position of the skill label
    thread = threading.Thread(target=skill_label_color_change, args=(skill_label, 3))
    thread.start()  # start the thread
```
`skill_label = dock.findChild(QtWidgets.QLabel, f"{skill}_label")` returned None and therefore an error occurred.

I changed all instances of `dock.findChild(QtWidgets.QLabel` to `mw.findChild(QtWidgets.QLabel)` and that fixed the problem for me.